### PR TITLE
remove group link

### DIFF
--- a/index.html
+++ b/index.html
@@ -154,7 +154,7 @@
     <header id="participate" class="special container">
       <h2>Participate in the Community</h2>
       <p>
-      Mirador's development, design, and maintenance is driven by community needs and ongoing feedback and discussion. Join us at our regularly scheduled community calls, on <a href="http://bit.ly/iiif-slack">IIIF slack</a>, or the <a href="https://groups.google.com/forum/#!forum/mirador-tech">mirador-tech</a> and <a href="https://groups.google.com/forum/#!forum/iiif-discuss">iiif-discuss</a> mailing lists. To suggest features, report bugs, and clarify usage, <a href="https://github.com/projectmirador/mirador/issues">submit a GitHub issue</a>.
+      Mirador's development, design, and maintenance is driven by community needs and ongoing feedback and discussion. Join us at our regularly scheduled community calls, on <a href="http://bit.ly/iiif-slack">IIIF slack</a> or the <a href="https://groups.google.com/forum/#!forum/iiif-discuss">iiif-discuss</a> mailing list. To suggest features, report bugs, and clarify usage, <a href="https://github.com/projectmirador/mirador/issues">submit a GitHub issue</a>.
       </p>
     </header>
     <p/>


### PR DESCRIPTION
This updates the last section of the page by removing a link to a Google group that is no longer active.