### PR TITLE
Update style.css

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1,5 +1,5 @@
 @import url("font-awesome.min.css");
-@import url("http://fonts.googleapis.com/css?family=Lato:300,400,900");
+@import url('https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,300;0,400;0,900;1,300;1,400;1,900&display=swap');
 
 /* Basic */
 


### PR DESCRIPTION
This addresses the issue reported by @marlo-longley in #50 

The font import declaration was a little stale. This PR updates style.css to use current method recommended by Google. 

To test: build the site locally and have a look at the inspector while on any page. The error should be gone.  